### PR TITLE
Feature/cu 8678p075c: updated scripts for maitaining registry

### DIFF
--- a/create-packages.py
+++ b/create-packages.py
@@ -29,7 +29,7 @@ def create_packages(ignored_packages):
 def main():
     args = sys.argv[1:]
     if len(args) != 1:
-        raise RuntimeError("wrong number of args. Need to be 1")
+        raise RuntimeError("wrong number of args. 1 is required")
     manifest_dir = args[0]
     ignored_packages = get_registry_ignore(manifest_dir)
     create_packages(ignored_packages)

--- a/create-packages.py
+++ b/create-packages.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+import os
+import subprocess
+import toml
+import sys
+
+def get_registry_ignore(manifest_dir):
+    path_reg_ignore = os.path.join(manifest_dir, '.registryignore')
+    res = []
+    try:
+        with open(path_reg_ignore, 'r') as file_reg_ignore:
+            for line in file_reg_ignore:
+                line = line.strip()
+                res.append(line)
+    except:
+        print(f'')
+    return res
+
+def create_packages(ignored_packages):
+    cmd = "cargo package --allow-dirty --workspace"
+    old_len = len(cmd)
+    for package in ignored_packages:
+        cmd += ' --exclude ' + package
+    if old_len == len(cmd):
+        cmd = "cargo package --allow-dirty"
+    subprocess.run(cmd, shell=True)
+    
+
+def main():
+    args = sys.argv[1:]
+    if len(args) != 1:
+        raise RuntimeError("wrong number of args. Need to be 1")
+    manifest_dir = args[0]
+    ignored_packages = get_registry_ignore(manifest_dir)
+    create_packages(ignored_packages)
+
+if __name__ == "__main__":
+    main()

--- a/registry-maintainer.py
+++ b/registry-maintainer.py
@@ -1,29 +1,28 @@
+#!/usr/bin/env python
+import sys
 import os
 import subprocess
 import json
 
-packages = os.environ.get("PACKAGES_DIR")
-registry = os.environ.get("REGISTRY")
-
-def cargo_index(name):
+def cargo_index(packages, name):
     path = str(os.path.join(packages, name))
     cmd = 'cargo index metadata --crate ' + path + ' --index-url url | grep "{*}"'
     return cmd
 
-def get_metainfo(directory, ignore_packages):
+def get_metainfo(packages):
     ans = {}
-    files = os.listdir(directory)
-    for file in files:
-        if not file.endswith(".crate"):
+    files = os.listdir(packages)
+    for package in os.listdir(packages):
+        if not package.endswith(".crate"):
             continue
-        cargo = cargo_index(file)
+        cargo = cargo_index(packages, package)
         metainfo = subprocess.run(cargo, shell=True, capture_output=True, text=True).stdout
         json_metainfo = json.loads(metainfo)
         name = json_metainfo['name']
-        ans[name] = [file, metainfo]
+        ans[name] = [package, metainfo]
     return ans
 
-def update_or_create_index(metainfo):
+def update_or_create_index(metainfo, registry):
     for name, meta in metainfo.items():
         dir_name = ""
         if len(name) <= 3:
@@ -46,7 +45,7 @@ def update_or_create_index(metainfo):
             json.dump(json.loads(meta[1]), json_file, separators=(",", ":"))
             json_file.write("\n")
 
-def move_crate_binaries(metainfo):
+def move_crate_binaries(packages, metainfo, registry):
     crates = os.path.join(registry, 'crates')
     for name, meta in metainfo.items():
         crate = os.path.join(crates, name)
@@ -66,8 +65,16 @@ def move_crate_binaries(metainfo):
         cmd = f'mv {target} {str(crate)}'
         subprocess.run(cmd, shell=True)
     
-ignore_packages = get_registry_ignore()
-metainfo = get_metainfo(packages)
-update_or_create_index(metainfo)
-move_crate_binaries(metainfo)
+def main():
+    args = sys.argv[1:]
+    if len(args) != 2:
+        raise RuntimeError("wrong number of args. 2 is required")
+    packages = args[0]
+    registry = args[1]
 
+    metainfo = get_metainfo(packages)
+    update_or_create_index(metainfo, registry)
+    move_crate_binaries(packages, metainfo, registry)
+
+if __name__ == "__main__":
+    main()

--- a/registry-maintainer.py
+++ b/registry-maintainer.py
@@ -10,7 +10,7 @@ def cargo_index(name):
     cmd = 'cargo index metadata --crate ' + path + ' --index-url url | grep "{*}"'
     return cmd
 
-def get_metainfo(directory):
+def get_metainfo(directory, ignore_packages):
     ans = {}
     files = os.listdir(directory)
     for file in files:
@@ -66,7 +66,7 @@ def move_crate_binaries(metainfo):
         cmd = f'mv {target} {str(crate)}'
         subprocess.run(cmd, shell=True)
     
-
+ignore_packages = get_registry_ignore()
 metainfo = get_metainfo(packages)
 update_or_create_index(metainfo)
 move_crate_binaries(metainfo)

--- a/version-modifier.py
+++ b/version-modifier.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+import sys
 import os
 import toml
 import re
@@ -41,6 +43,15 @@ def get_workspace_members_directories(root_directory):
     ))
     
     
+def main():
+    args = sys.argv[1:]
+    if len(args) != 2:
+        raise RuntimeError("wrong number of args. 2 is required")
+    manifest_dir = args[0]
+    commit_hash = args[1]
 
-workspace_members = get_workspace_members_directories(manifest_dir)
-modify_members_versions(workspace_members, commit_hash)
+    workspace_members = get_workspace_members_directories(manifest_dir)
+    modify_members_versions(workspace_members, commit_hash)
+
+if __name__ == "__main__":
+    main()

--- a/version-modifier.py
+++ b/version-modifier.py
@@ -5,7 +5,6 @@ import re
 commit_hash = str(os.environ.get("SHORT_COMMIT_HASH"))
 manifest_dir = str(os.environ.get("CARGO_MANIFEST_DIR"))
 
-
 def modify_cargo_toml_version(file_path, commit_hash):
     with open(file_path, 'r') as f:
         cargo_toml = toml.load(f)


### PR DESCRIPTION
Now we can use .registryingnore files in cargo manifest directories to ignore some packages to be packaged. Also I have made some changes in other scripts to make them more pleasant to use